### PR TITLE
9.1.2 Specfile Fixes

### DIFF
--- a/rpmbuild/SOURCES/astats_over_http-1.6-9.1.x.patch
+++ b/rpmbuild/SOURCES/astats_over_http-1.6-9.1.x.patch
@@ -1,3 +1,15 @@
+diff --git a/plugins/Makefile.am b/plugins/Makefile.am
+index eeee583a4..bc190a2fa 100644
+--- a/plugins/Makefile.am
++++ b/plugins/Makefile.am
+@@ -61,6 +61,7 @@ if BUILD_EXPERIMENTAL_PLUGINS
+
+ include experimental/access_control/Makefile.inc
+ include experimental/acme/Makefile.inc
++include experimental/astats_over_http/Makefile.inc
+ include experimental/cache_fill/Makefile.inc
+ include experimental/cert_reporting_tool/Makefile.inc
+ include experimental/collapsed_forwarding/Makefile.inc
 diff --git a/plugins/experimental/astats_over_http/CHANGELOG b/plugins/experimental/astats_over_http/CHANGELOG
 new file mode 100644
 index 000000000..83f9b7aa2

--- a/rpmbuild/SOURCES/astats_over_http-1.6-9.1.x.patch
+++ b/rpmbuild/SOURCES/astats_over_http-1.6-9.1.x.patch
@@ -1,7 +1,7 @@
 diff --git a/plugins/Makefile.am b/plugins/Makefile.am
 index eeee583a4..bc190a2fa 100644
---- a/trafficserver-9.1.2/plugins/Makefile.am
-+++ b/trafficserver-9.1.2/plugins/Makefile.am
+--- a/plugins/Makefile.am
++++ b/plugins/Makefile.am
 @@ -61,6 +61,7 @@ if BUILD_EXPERIMENTAL_PLUGINS
 
  include experimental/access_control/Makefile.inc

--- a/rpmbuild/SOURCES/astats_over_http-1.6-9.1.x.patch
+++ b/rpmbuild/SOURCES/astats_over_http-1.6-9.1.x.patch
@@ -2,7 +2,7 @@ diff --git a/plugins/Makefile.am b/plugins/Makefile.am
 index eeee583a4..bc190a2fa 100644
 --- a/plugins/Makefile.am
 +++ b/plugins/Makefile.am
-@@ -59,6 +59,7 @@ if BUILD_EXPERIMENTAL_PLUGINS
+@@ -61,6 +61,7 @@ if BUILD_EXPERIMENTAL_PLUGINS
 
  include experimental/access_control/Makefile.inc
  include experimental/acme/Makefile.inc

--- a/rpmbuild/SOURCES/astats_over_http-1.6-9.1.x.patch
+++ b/rpmbuild/SOURCES/astats_over_http-1.6-9.1.x.patch
@@ -1,15 +1,3 @@
-diff --git a/plugins/Makefile.am b/plugins/Makefile.am
-index eeee583a4..bc190a2fa 100644
---- a/plugins/Makefile.am
-+++ b/plugins/Makefile.am
-@@ -61,6 +61,7 @@ if BUILD_EXPERIMENTAL_PLUGINS
- 
- include experimental/access_control/Makefile.inc
- include experimental/acme/Makefile.inc
-+include experimental/astats_over_http/Makefile.inc
- include experimental/cache_fill/Makefile.inc
- include experimental/cert_reporting_tool/Makefile.inc
- include experimental/collapsed_forwarding/Makefile.inc
 diff --git a/plugins/experimental/astats_over_http/CHANGELOG b/plugins/experimental/astats_over_http/CHANGELOG
 new file mode 100644
 index 000000000..83f9b7aa2

--- a/rpmbuild/SOURCES/astats_over_http-1.6-9.1.x.patch
+++ b/rpmbuild/SOURCES/astats_over_http-1.6-9.1.x.patch
@@ -2,7 +2,7 @@ diff --git a/plugins/Makefile.am b/plugins/Makefile.am
 index eeee583a4..bc190a2fa 100644
 --- a/plugins/Makefile.am
 +++ b/plugins/Makefile.am
-@@ -61,6 +61,7 @@ if BUILD_EXPERIMENTAL_PLUGINS
+@@ -59,6 +59,7 @@ if BUILD_EXPERIMENTAL_PLUGINS
 
  include experimental/access_control/Makefile.inc
  include experimental/acme/Makefile.inc

--- a/rpmbuild/SOURCES/astats_over_http-1.6-9.1.x.patch
+++ b/rpmbuild/SOURCES/astats_over_http-1.6-9.1.x.patch
@@ -1,7 +1,7 @@
 diff --git a/plugins/Makefile.am b/plugins/Makefile.am
 index eeee583a4..bc190a2fa 100644
---- a/plugins/Makefile.am
-+++ b/plugins/Makefile.am
+--- a/trafficserver-9.1.2/plugins/Makefile.am
++++ b/trafficserver-9.1.2/plugins/Makefile.am
 @@ -61,6 +61,7 @@ if BUILD_EXPERIMENTAL_PLUGINS
 
  include experimental/access_control/Makefile.inc

--- a/rpmbuild/SPECS/trafficserver-9.1.2.spec
+++ b/rpmbuild/SPECS/trafficserver-9.1.2.spec
@@ -43,15 +43,11 @@ Apache Traffic Server for Traffic Control with astats_over_http plugin
 
 %prep
 %setup
-echo "============="
-pwd
-ls -al
-echo "============="
 %patch0 -p1
-%patch1 
-%patch2
-%patch3
-%patch4
+%patch1 -p1
+%patch2 -p1
+%patch3 -p1
+%patch4 -p1
 autoreconf -vfi
 
 #%setup

--- a/rpmbuild/SPECS/trafficserver-9.1.2.spec
+++ b/rpmbuild/SPECS/trafficserver-9.1.2.spec
@@ -41,9 +41,13 @@ Requires(postun): initscripts
 %description
 Apache Traffic Server for Traffic Control with astats_over_http plugin
 
-%prep
+#%prep
 
 %setup
+echo "============="
+pwd
+ls -al
+echo "============="
 %patch0 -p1
 %patch1 
 %patch2

--- a/rpmbuild/SPECS/trafficserver-9.1.2.spec
+++ b/rpmbuild/SPECS/trafficserver-9.1.2.spec
@@ -41,8 +41,7 @@ Requires(postun): initscripts
 %description
 Apache Traffic Server for Traffic Control with astats_over_http plugin
 
-#%prep
-
+%prep
 %setup
 echo "============="
 pwd

--- a/rpmbuild/SPECS/trafficserver-9.1.2.spec
+++ b/rpmbuild/SPECS/trafficserver-9.1.2.spec
@@ -42,12 +42,9 @@ Requires(postun): initscripts
 Apache Traffic Server for Traffic Control with astats_over_http plugin
 
 %prep
-rm -rf %{name}-%{version}
-#git clone -b %{version} https://github.com/apache/trafficserver.git %{name}-%{version}
 
-#%setup -D -n %{name} -T
 %setup
-%patch0 -p1
+%patch0
 %patch1 
 %patch2
 %patch3

--- a/rpmbuild/SPECS/trafficserver-9.1.2.spec
+++ b/rpmbuild/SPECS/trafficserver-9.1.2.spec
@@ -44,7 +44,7 @@ Apache Traffic Server for Traffic Control with astats_over_http plugin
 %prep
 
 %setup
-%patch0
+%patch0 -p1
 %patch1 
 %patch2
 %patch3

--- a/rpmbuild/SPECS/trafficserver-9.1.2.spec
+++ b/rpmbuild/SPECS/trafficserver-9.1.2.spec
@@ -8,9 +8,9 @@ Group:		Applications/Communications
 License:	Apache License, Version 2.0
 URL:		https://github.com/apache/trafficserver
 Epoch:          13475
-#Source0:        %{name}-%{version}-%{epoch}.tar.bz2
+Source0:       %{name}-%{version}-%{epoch}.tar.bz2
 %undefine _disable_source_fetch
-Source0:        https://github.com/apache/trafficserver/archive/refs/tags/9.1.2.tar.gz
+#Source0:        https://github.com/apache/trafficserver/archive/refs/tags/9.1.2.tar.gz
 #Source1:        trafficserver.service
 Source2:        trafficserver.sysconfig
 Source3:        trafficserver.tmpfilesd


### PR DESCRIPTION
# Changelog

- Changed `Source0` to use local TAR file.
- Removed extra base directory wipe and re-download of source from GitHub.
- Fixed patch commands to use the `-p1` flag as patch interprets the `a/` and `b/` from git diffs as part of the path.